### PR TITLE
[drwb] sync router path with machine

### DIFF
--- a/src/components/layout/DRLayout.tsx
+++ b/src/components/layout/DRLayout.tsx
@@ -3,6 +3,7 @@ import ChatSidebar from "./ChatSidebar";
 import CodeViewer from "../viewer/CodeViewer";
 import { Card } from "../ui/Card";
 import AppRoutes from "../../router/AppRoutes";
+import { useRouteSync } from "../../hooks/useRouteSync";
 
 interface Props {
   machine: ReturnType<typeof import("../../state/useAppMachine").useAppMachine>;
@@ -11,6 +12,7 @@ interface Props {
 export default function DRLayout({ machine }: Props) {
   const { state, send } = machine;
 
+  useRouteSync(state, send);
   // Debug logging
   console.log("DRLayout received machine:", machine);
   console.log("DRLayout state:", state);

--- a/src/hooks/useRouteSync.ts
+++ b/src/hooks/useRouteSync.ts
@@ -1,0 +1,30 @@
+import { useEffect } from "react";
+import { useLocation, matchPath } from "react-router-dom";
+import type { StateFrom } from "xstate";
+import { appMachine, type AppEvent } from "../state/appMachine";
+
+export function useRouteSync(
+  state: StateFrom<typeof appMachine>,
+  send: (event: AppEvent) => void
+) {
+  const location = useLocation();
+
+  useEffect(() => {
+    const { pathname } = location;
+    const inRecipe =
+      pathname === "/overview" || matchPath("/step/:id", pathname) !== null;
+
+    if (pathname === "/finalise") {
+      if (!state.matches("finalising")) {
+        send({ type: "FINALISE" });
+      }
+    } else if (inRecipe) {
+      if (state.matches("finalising")) {
+        send({ type: "BACK_TO_RECIPE" });
+      }
+      if (state.matches("viewingCode")) {
+        send({ type: "CLOSE_ALL" });
+      }
+    }
+  }, [location, location.pathname, state, send]);
+}

--- a/src/state/appMachine.ts
+++ b/src/state/appMachine.ts
@@ -11,7 +11,8 @@ export type AppEvent =
   | { type: "OPEN_FILE"; id: string }
   | { type: "CLOSE_ALL" }
   | { type: "FINALISE" }
-  | { type: "RESET" };
+  | { type: "RESET" }
+  | { type: "BACK_TO_RECIPE" };
 
 export interface AppContext {
   dir?: FileSystemDirectoryHandle;
@@ -90,7 +91,11 @@ export const appMachine = createMachine({
     },
 
     finalising: {
-      on: { RESET: "idle", OPEN_FILE: "viewingCode" },
+      on: {
+        RESET: "idle",
+        OPEN_FILE: "viewingCode",
+        BACK_TO_RECIPE: "ready",
+      },
     },
   },
 });

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -14,14 +14,17 @@ test.describe("Design Recipe Assistant - Smoke Tests", () => {
     // Click on Step 0
     await page.getByRole("link", { name: "Step 0 — Restate" }).click({ timeout: 10000 });
     await expect(page).toHaveURL("/step/0");
+    await expect(page.getByRole("heading", { name: /Step 0/i })).toBeVisible();
 
     // Click on Step 1
     await page.getByRole("link", { name: "Step 1 — Data Definitions" }).click();
     await expect(page).toHaveURL("/step/1");
+    await expect(page.getByRole("heading", { name: /Step 1/i })).toBeVisible();
 
     // Click on Overview
     await page.getByRole("link", { name: "Project Overview" }).click();
     await expect(page).toHaveURL("/overview");
+    await expect(page.getByRole("heading", { name: /Project Overview/i })).toBeVisible();
   });
 
   test("should show step 0 after navigation", async ({ page }) => {


### PR DESCRIPTION
## Context
- UI showed mismatched content when navigating because the global state machine never reacted to route changes
- e2e test needed stronger assertions on page contents

## Changes
- add `useRouteSync` hook watching `useLocation`
- map `/overview`, `/step/:id`, `/finalise` to machine events
- expose `BACK_TO_RECIPE` transition and use hook inside layout
- strengthen smoke test expectations

## Checklist
- [x] `pnpm run typecheck`
- [x] `pnpm run lint --fix`
- [x] `pnpm run test`
- [x] `pnpm run test:e2e` *(fails: link not found)*


------
https://chatgpt.com/codex/tasks/task_e_687f31fbc3dc8331b0a5cc5d713f4243