### PR TITLE
[drwb] persist project handle across sessions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,10 +3,12 @@ import DRLayout from "./components/layout/DRLayout";
 import { ProjectGate } from "./components/project/ProjectGate";
 import { ToastContainer } from "./components/ui/ToastContainer";
 import { useAppMachine } from "./state/useAppMachine";
+import { useAutoReconnectProject } from "./hooks/useAutoReconnectProject";
 import { AppActorContext } from "./contexts/AppActorContext";
 
 export default function App() {
   const machine = useAppMachine(); // {state,send,actor}
+  useAutoReconnectProject();
 
 
   return (

--- a/src/components/project/ProjectGate.tsx
+++ b/src/components/project/ProjectGate.tsx
@@ -42,7 +42,7 @@ export function ProjectGate({ children }: ProjectGateProps) {
 
             // Create recent entry
             const recentEntry: RecentEntry = {
-              id: crypto.randomUUID(),
+              id: state.context.dirKey!,
               name: state.context.dir.name,
               path: state.context.dir.name,
               handle: state.context.dir,

--- a/src/hooks/useAutoReconnectProject.ts
+++ b/src/hooks/useAutoReconnectProject.ts
@@ -1,0 +1,37 @@
+import { useEffect } from "react";
+import { loadLastProjectHandle } from "../utils/lastProject";
+import { useAppMachine } from "../state/useAppMachine";
+import { ensureDrKey } from "./useDrKey";
+
+export function useAutoReconnectProject() {
+  const { send } = useAppMachine();
+
+  useEffect(() => {
+    (async () => {
+      const handle = await loadLastProjectHandle();
+      if (!handle) return;
+
+      const perm = await handle.queryPermission();
+      if (perm !== "granted") return;
+
+      const dirKey = await ensureDrKey(handle);
+
+      const files: File[] = [];
+      async function walk(dir: FileSystemDirectoryHandle, prefix = "") {
+        for await (const [name, entry] of dir.entries()) {
+          const path = prefix ? `${prefix}/${name}` : name;
+          if (entry.kind === "file") {
+            const file = await (entry as FileSystemFileHandle).getFile();
+            Object.defineProperty(file, "webkitRelativePath", { value: path });
+            files.push(file);
+          } else {
+            await walk(entry as FileSystemDirectoryHandle, path);
+          }
+        }
+      }
+      await walk(handle);
+
+      send({ type: "SELECTED", dir: handle, files, dirKey });
+    })();
+  }, [send]);
+}

--- a/src/hooks/useDrKey.ts
+++ b/src/hooks/useDrKey.ts
@@ -1,0 +1,18 @@
+import { getFile, writeText } from "./useYjs";
+
+/**
+ * Return a per-project UUID, persisting it to
+ * `.design-recipe/dr-key` if it does not exist yet.
+ */
+export async function ensureDrKey(
+  dir: FileSystemDirectoryHandle
+): Promise<string> {
+  // Try to read existing key
+  const existing = await getFile(dir, "dr-key");
+  if (existing) return (await existing.text()).trim();
+
+  // Create new one
+  const key = crypto.randomUUID();
+  await writeText(dir, "dr-key", key);
+  return key;
+}

--- a/src/hooks/useProject.ts
+++ b/src/hooks/useProject.ts
@@ -5,6 +5,6 @@ export function useProject() {
 
   return {
     dirHandle: currentProject?.handle || null,
-    dirKey: currentProject?.id || null, // Will be updated to use .dr-key file
+    dirKey: currentProject?.id || null,
   };
 }

--- a/src/hooks/useYjs.ts
+++ b/src/hooks/useYjs.ts
@@ -109,11 +109,14 @@ export function useDoc(stepId: string): Y.Doc | null {
   const updateHandlerRef = useRef<((update: Uint8Array) => void) | null>(null);
 
   useEffect(() => {
-    if (!dirHandle || !dirKey) {
+    if (!dirHandle) {
       setDoc(null);
       return;
     }
-
+    if (!dirKey) {
+      setDoc(null);
+      return;
+    }
     const key = `${dirKey}:${stepId}`;
 
     // Get or create doc from cache

--- a/src/state/appMachine.ts
+++ b/src/state/appMachine.ts
@@ -4,7 +4,12 @@ import type { DRAnalysis } from "../treesitter/types";
 /** Public events */
 export type AppEvent =
   | { type: "PICK" }
-  | { type: "SELECTED"; dir: FileSystemDirectoryHandle; files: File[] }
+  | {
+      type: "SELECTED";
+      dir: FileSystemDirectoryHandle;
+      files: File[];
+      dirKey: string;
+    }
   | { type: "CANCEL" }
   | { type: "PARSE_OK"; analysis: DRAnalysis }
   | { type: "PARSE_FAIL"; message: string }
@@ -16,6 +21,7 @@ export type AppEvent =
 
 export interface AppContext {
   dir?: FileSystemDirectoryHandle;
+  dirKey?: string;
   files: File[];
   analysis?: DRAnalysis;
   openTabs: string[];
@@ -43,6 +49,7 @@ export const appMachine = createMachine({
           actions: assign({
             dir: ({ event }) => event.dir,
             files: ({ event }) => event.files,
+            dirKey: ({ event }) => event.dirKey,
           }),
         },
         CANCEL: "idle",

--- a/src/state/useAppMachine.ts
+++ b/src/state/useAppMachine.ts
@@ -1,6 +1,8 @@
 import { useMachine } from "@xstate/react";
 import { appMachine } from "./appMachine";
 import { clearDocCache } from "../hooks/useYjs";
+import { ensureDrKey } from "../hooks/useDrKey";
+import { saveLastProjectHandle } from "../utils/lastProject";
 
 /**
  * Adapter that provides the state machine with helper functions
@@ -51,7 +53,12 @@ export function useAppMachine() {
         }
       }
       await walk(dir);
-      wrappedSend({ type: "SELECTED", dir, files });
+
+      /* NEW – create or load dr-key */
+      const dirKey = await ensureDrKey(dir);
+
+      wrappedSend({ type: "SELECTED", dir, files, dirKey });
+      await saveLastProjectHandle(dir);
     } catch {
       wrappedSend({ type: "CANCEL" });
     }

--- a/src/utils/lastProject.ts
+++ b/src/utils/lastProject.ts
@@ -1,0 +1,15 @@
+import { get, set, del } from "idb-keyval";
+
+const KEY = "dr-last-project";
+
+export async function saveLastProjectHandle(
+  handle: FileSystemDirectoryHandle
+) {
+  await set(KEY, handle);
+}
+
+export const loadLastProjectHandle = (): Promise<
+  FileSystemDirectoryHandle | undefined
+> => get(KEY);
+
+export const clearLastProjectHandle = () => del(KEY);

--- a/tests/e2e/reconnect.spec.ts
+++ b/tests/e2e/reconnect.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from "@playwright/test";
+
+test("auto-reconnect skips when no handle", async ({ page }) => {
+  // Clean origin storage
+  await page.context().clearCookies();
+  await page.goto("/");
+  await expect(page.locator('text=Design‑Recipe Workbench')).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- store persistent `dr-key` in project folder
- remember last picked folder and auto-reconnect on load
- expose reconnect hook in `App`
- keep project id stable via `dirKey`
- add minimal reconnect e2e test

## Testing
- `pnpm run typecheck`
- `pnpm run lint --fix`
- `pnpm exec vitest run`
- `CI=1 pnpm run test:e2e` *(fails: timeline items disabled until project is loaded)*

------
https://chatgpt.com/codex/tasks/task_e_687f996e31308331bdccf43943d6fff0