### PR TITLE
[drwb] use existing app actor in reconnect hook

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import { AppActorContext } from "./contexts/AppActorContext";
 
 export default function App() {
   const machine = useAppMachine(); // {state,send,actor}
-  useAutoReconnectProject();
+  useAutoReconnectProject(machine.actor);
 
 
   return (

--- a/src/hooks/useAutoReconnectProject.ts
+++ b/src/hooks/useAutoReconnectProject.ts
@@ -1,10 +1,13 @@
 import { useEffect } from "react";
+import { ActorRefFrom } from "xstate";
 import { loadLastProjectHandle } from "../utils/lastProject";
-import { useAppMachine } from "../state/useAppMachine";
+import { appMachine } from "../state/appMachine";
 import { ensureDrKey } from "./useDrKey";
 
-export function useAutoReconnectProject() {
-  const { send } = useAppMachine();
+export function useAutoReconnectProject(
+  actor: ActorRefFrom<typeof appMachine>,
+) {
+  const { send } = actor;
 
   useEffect(() => {
     (async () => {


### PR DESCRIPTION
## Summary
- reuse running app actor in auto reconnect hook
- wire App to pass actor to reconnect hook

## Testing
- `pnpm run typecheck`
- `pnpm run lint --fix`
- `pnpm run test --run`
- `CI=1 pnpm run test:e2e` *(fails: timeline items disabled until project is loaded)*


------
https://chatgpt.com/codex/tasks/task_e_689485c75a588331a446c2a376b5688a